### PR TITLE
Addes ExcludeAnnotationTransformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ use case.
 
 The annotation interface of `merky` gives the user control over the tokenization of
 a complex data structure.  In effect, the user annotates the data structure to instruct
-`merky` on which portions should be tokenized.
+`merky` on which portions should be tokenized or excluded from tokenization.
 
 Using the `merky.AnnotationTransformer`:
 * All structures convert to their canonical forms.
@@ -103,9 +103,16 @@ Using the `merky.AnnotationTransformer`:
 * Nested structures are only tokenized if they have a `__merky__` attribute with a
   truthy value.
 
+Using the `merky.ExcludeAnnotationTransformer`:
+* The top-level structure passed to `transform()` is always tokenized.
+* All structures convert to their canonical forms.
+* Nested structures are always tokenized except if they have a `__merky__` 
+  attribute with a truthy value.
+
 The `merky.annotate` helper can wrap any arbitrary structure such that the
 `__merky__` truth requirement is met, causing the `AnnotationTransformer` to tokenize
-that wrapped structure.
+that wrapped structure or the `ExcludeAnnotationTransformer` to exclude the structure
+from tokenization.
 
 ### Example annotated transformations
 

--- a/merky/__init__.py
+++ b/merky/__init__.py
@@ -3,10 +3,12 @@ from merky import transformer
 
 __all__ = ('Transformer',
            'AnnotationTransformer',
+           'ExcludeAnnotationTransformer',
            'annotate',
           )
 
 annotate = util.annotate
 Transformer = transformer.Transformer
 AnnotationTransformer = transformer.AnnotationTransformer
+ExcludeAnnotationTransformer = transformer.ExcludeAnnotationTransformer
 

--- a/merky/test/exclude_annotation_nesting_test.py
+++ b/merky/test/exclude_annotation_nesting_test.py
@@ -1,0 +1,153 @@
+import collections
+
+from nose import tools
+from . import words
+import merky
+
+BASIC_SEQ = (words.SHEKELS, words.EUROS, words.EPEES)
+BASIC_SEQ_JSON = words.unify('[',
+                                '"', words.SHEKELS, '",',
+                                '"', words.EUROS, '",',
+                                '"', words.EPEES, '"',
+                             ']')
+BASIC_SEQ_HASH = '8129cb64b06e72be46eec5037eafc1583586325a'
+
+UNANNOTATED_NESTED_SEQ = (words.ANGSTROM, BASIC_SEQ, 213, -315)
+UNANNOTATED_NESTED_SEQ_JSON = words.unify('[',
+                                            '"', words.ANGSTROM, '",',
+                                            BASIC_SEQ_JSON, ',',
+                                            '213,',
+                                            '-315',
+                                          ']')
+UNANNOTATED_NESTED_SEQ_HASH = '14fe00c4e749eb96b8c66370902ac90a4f0d52fe'
+
+BASIC_DICT = {words.SHEKELS: words.EUROS, words.ANGSTROM: words.EPEES}
+BASIC_DICT_ORDERED = collections.OrderedDict((
+                        (words.ANGSTROM, words.EPEES),
+                        (words.SHEKELS, words.EUROS),
+                     ))
+BASIC_DICT_JSON = words.unify('{',
+                                '"', words.ANGSTROM, '":"', words.EPEES, '",',
+                                '"', words.SHEKELS, '":"', words.EUROS, '"',
+                              '}')
+BASIC_DICT_HASH = 'b22023acbbc3af979ba46d986706d8da7614f722'
+
+UNANNOTATED_NESTED_DICT = {"dict": dict(BASIC_DICT), "list": BASIC_SEQ}
+UNANNOTATED_NESTED_DICT_ORDERED = collections.OrderedDict((
+                                    ("dict", BASIC_DICT_ORDERED),
+                                    ("list", list(BASIC_SEQ))
+                                  ))
+UNANNOTATED_NESTED_DICT_JSON = words.unify('{',
+                                            '"dict":', BASIC_DICT_JSON, ',',
+                                            '"list":', BASIC_SEQ_JSON,
+                                           '}')
+UNANNOTATED_NESTED_DICT_HASH = '616bcc08fa64f4e8ed9cd7395c8981cdff045baf'
+UNANNOTATED_NESTED_DICT_TOKENIZED = collections.OrderedDict((
+                                      ("dict", BASIC_DICT_HASH),
+                                      ("list", BASIC_SEQ_HASH)
+                                     ))
+
+
+
+
+def test_simple_unannotated_list():
+    # It always does the top level guy regardless of annotation.
+    t = merky.ExcludeAnnotationTransformer()
+    r = t.transform(BASIC_SEQ)
+    tools.assert_equal((BASIC_SEQ_HASH, list(BASIC_SEQ)), next(r))
+    tools.assert_raises(StopIteration, next, r)
+
+
+def test_nested_unannotated_list():
+    # Top level always gets done, but this time, the nested guy wil be too.
+    t = merky.ExcludeAnnotationTransformer()
+    r = t.transform(UNANNOTATED_NESTED_SEQ)
+    # We get the inner guy first, who is tokenized due to annotation
+    tools.assert_equal((BASIC_SEQ_HASH, list(BASIC_SEQ)), next(r))
+    # The outer guy is different this time, as the token replaced the nested list.
+    # SHA1 of json of [words.ANGSTROM, BASIC_SEQ_HASH, 213, -315]
+    tools.assert_equal(("3e2f759672d412ed84b7359e2613c94cfee250f2", [words.ANGSTROM, BASIC_SEQ_HASH, 213, -315]),
+                       next(r))
+    tools.assert_raises(StopIteration, next, r)
+
+
+def test_nested_annotated_list():
+    # And again, it always does the top level guy.  But since no members are annotated, it
+    # will explode out anything else.
+    t = merky.ExcludeAnnotationTransformer()
+    r = t.transform((words.ANGSTROM, merky.annotate(BASIC_SEQ), 213, -315))
+    tools.assert_equal((UNANNOTATED_NESTED_SEQ_HASH, [words.ANGSTROM, list(BASIC_SEQ), 213, -315]), next(r))
+    tools.assert_raises(StopIteration, next, r)
+
+
+def test_simple_unannotated_dict():
+    t = merky.ExcludeAnnotationTransformer()
+    r = t.transform(BASIC_DICT)
+    tools.assert_equal((BASIC_DICT_HASH, BASIC_DICT_ORDERED), next(r))
+    tools.assert_raises(StopIteration, next, r)
+
+
+def test_nested_unannotated_dict():
+    t = merky.ExcludeAnnotationTransformer()
+    r = t.transform(UNANNOTATED_NESTED_DICT)
+    # We get the inner dict first, who is tokenized due to lack of annotation
+    tools.assert_equal((BASIC_DICT_HASH, BASIC_DICT_ORDERED), next(r))
+    # We get the inner list second, who is tokenized due to lack of annotation
+    tools.assert_equal((BASIC_SEQ_HASH, list(BASIC_SEQ)), next(r))
+    # The outer guy is different this time, as tokens replace the nested dict and list
+    # SHA1 of json of [words.ANGSTROM, BASIC_SEQ_HASH, 213, -315]
+    tools.assert_equal((UNANNOTATED_NESTED_DICT_HASH, UNANNOTATED_NESTED_DICT_TOKENIZED),
+                       next(r))
+    tools.assert_raises(StopIteration, next, r)
+
+
+def test_mixed_nesting():
+    t = merky.ExcludeAnnotationTransformer()
+    x = {"a": merky.annotate([
+                    {"a": merky.annotate({"a": "A", "b": "B"}), "b": "B"},
+                    {"nothing": "special"},
+                ]),
+         "b": [
+                merky.annotate({"c": "C", "d": "D"}),
+                {"e": "E", "f": "F"},
+              ],
+        }
+    r = t.transform(x)
+    # Lowest level: x["a"][0]
+    tools.assert_equal(('9999c10f0f35c46a472e16ecec8d7cac6b0ac127',
+                        collections.OrderedDict([('a', collections.OrderedDict([('a', 'A'), ('b', 'B')])), ('b', 'B')])),
+                       next(r))
+
+    # Next up: x["a"][1]
+    tools.assert_equal(('0018774ddc2b3b541fbc4420dd74938993399798',
+                        collections.OrderedDict([('nothing', 'special')])),
+                        next(r))
+
+    # Next up: x["b"][1]
+    tools.assert_equal(('37c3a03f839031d9a6eb3281b792a0cb6e02e79d',
+                        collections.OrderedDict((
+                            ('e', 'E'),
+                            ('f', 'F'),
+                        ))),
+                       next(r))
+
+    # Penultimate: x["b"]
+    tools.assert_equal(('a6af006f34fec3ea34cf23b6505fd8eed6ccb3d6',
+                        [collections.OrderedDict((
+                            ('c', 'C'),
+                            ('d', 'D')
+                         )),
+                         '37c3a03f839031d9a6eb3281b792a0cb6e02e79d']
+                        ),
+                       next(r))
+
+    # Final, top level
+    tools.assert_equal(('519776beb2cec6f8810e3b8ff25a248a2415985a',
+                        collections.OrderedDict((
+                            ('a', ['9999c10f0f35c46a472e16ecec8d7cac6b0ac127',
+                                   '0018774ddc2b3b541fbc4420dd74938993399798']),
+                            ('b', 'a6af006f34fec3ea34cf23b6505fd8eed6ccb3d6'))
+                        )),
+                       next(r))
+
+    tools.assert_raises(StopIteration, next, r)

--- a/merky/transformer.py
+++ b/merky/transformer.py
@@ -112,3 +112,18 @@ class AnnotationTransformer(Transformer):
     def get_dispatcher(self):
         return tree.annotation_dispatcher
 
+
+class ExcludeAnnotationTransformer(Transformer):
+    """
+    A merky Transformer that normalizes the input structure, but excludes
+    structures that have been "annotated" with the ``__merky__`` attribute with a
+    true value.
+
+    The top-level structure is always tokenized and yielded regardless of the presence of the
+    annotation.
+
+    See the `merky.util.annotate` helper for annotating your data structures for use with
+    this transformer.
+    """
+    def get_dispatcher(self):
+        return tree.exclude_annotation_dispatcher

--- a/merky/tree.py
+++ b/merky/tree.py
@@ -77,6 +77,11 @@ def walker(structure, dispatcher, tokenizer):
             accum.append(value)
 
 
+def notter(handler):
+    def handle(item):
+        next_item, next_col, next_tok = handler(item)
+        return next_item, next_col, not next_tok
+    return handle
 
 
 map_annotation_handler = annotation_handler(map_handler, 'map_annotation_handler')
@@ -92,4 +97,8 @@ annotation_dispatcher = dispatcher(string_handler,
                                    seq_annotation_handler,
                                    default_handler)
 
+exclude_annotation_dispatcher = dispatcher(string_handler,
+                                           notter(map_annotation_handler),
+                                           notter(seq_annotation_handler),
+                                           default_handler)
 


### PR DESCRIPTION
The `ExcludeAnnotationTransformer` allows the user mark nested structures
to be excluded from tokenization.